### PR TITLE
Set sync=false in the sinks of the AES67 relay

### DIFF
--- a/src/bin/aes67-relay.rs
+++ b/src/bin/aes67-relay.rs
@@ -164,7 +164,10 @@ fn create_rtsp_input(rtsp_url: &Url) -> gst::Element {
 }
 
 fn create_null_output() -> gst::Element {
-    gst::ElementFactory::make("fakesink").build().unwrap()
+    gst::ElementFactory::make("fakesink")
+        .property("sync", false)
+        .build()
+        .unwrap()
 }
 
 // wait-for-connection=false means we will consume buffers and drop them
@@ -181,11 +184,13 @@ fn create_null_output() -> gst::Element {
 fn create_srt_output(srt_url: Url) -> gst::Element {
     let sink = gst::Element::make_from_uri(gst::URIType::Sink, srt_url.as_str(), None).unwrap();
     sink.set_property("wait-for-connection", false);
+    sink.set_property("sync", false);
     sink
 }
 
 fn create_udp_output(udp_url: Url) -> gst::Element {
     let sink = gst::Element::make_from_uri(gst::URIType::Sink, udp_url.as_str(), None).unwrap();
+    sink.set_property("sync", false);
     sink
 }
 


### PR DESCRIPTION
The input streams are already live and simply forwarded so (apart from jitter correction) synchronization has no effects.

If synchronization should happen then it would be required for the pipeline to actually use the same clock as the incoming stream.