### PR TITLE
audio-chunker, fragment-encoder: use chunk metas for reduced latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "gstreamer-rtsp-server",
  "md5",
  "once_cell",
+ "smallvec",
  "url",
 ]
 
@@ -954,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ md5 = "0.7.0"
 once_cell = "1.9.0"
 url = "2.2.2"
 bitstream-io = "2"
+smallvec = "1.14.0"
 
 [dependencies.glib]
 version = "0.20"

--- a/src/bin/fragment-enc.rs
+++ b/src/bin/fragment-enc.rs
@@ -22,12 +22,8 @@ use gst_rtp::prelude::RTPHeaderExtensionExt;
 
 use once_cell::sync::Lazy;
 
-use atomic_refcell::AtomicRefCell;
-
 use std::fs::File;
 use std::io::prelude::*;
-
-use std::sync::Arc;
 
 use url::Url;
 
@@ -408,13 +404,12 @@ for reproducibility",
         .dynamic_cast::<gst_app::AppSink>()
         .expect("Sink element is expected to be an appsink!");
 
-    // Todo: can probably drop the Arc here now
-    let chunk_collector = Arc::new(AtomicRefCell::new(ChunkCollector { frames: vec![] }));
+    let mut chunk_collector = ChunkCollector { frames: vec![] };
 
     appsink.set_callbacks(
         gst_app::AppSinkCallbacks::builder()
             .new_sample(move |appsink| {
-                let mut collector = chunk_collector.borrow_mut();
+                let collector = &mut chunk_collector;
 
                 let sample = appsink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
                 let buf = sample.buffer().unwrap().copy();


### PR DESCRIPTION
Use metas to delineate chunk start/end boundaries instead of custom events, to bring down latency.
    
The problem was that the custom event sent after the last buffer of the chunk would only make it through the audio encoder once there's more data to push out, so only once the next chunk is ready, adding at least one (if not more, on packet loss) chunks latency.
    
With metas the chunk end meta makes it through the audio encoder immediately on the last encoded audio frame.